### PR TITLE
Add More Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,6 @@ venv.bak/
 .mypy_cache/
 
 molecule/*
-!molecule/common/*
+!molecule/common/
 !molecule/gen-scenarios.py
-!molecule/ubuntu/*
+!molecule/ubuntu/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ services: docker
 language: python
 python: 3.8
 env:
+  - SCENARIO=allinone-centos7
+  - SCENARIO=allinone-centos8
+  - SCENARIO=allinone-ubuntu18.04
+  - SCENARIO=twoinone-centos7
+  - SCENARIO=twoinone-centos8
+  - SCENARIO=twoinone-ubuntu18.04
   - SCENARIO=archiveinterface-centos7
   - SCENARIO=archiveinterface-centos8
   - SCENARIO=archiveinterface-ubuntu18.04

--- a/molecule/common/allinone-converge.yml.j2
+++ b/molecule/common/allinone-converge.yml.j2
@@ -1,0 +1,116 @@
+---
+{{ warning_msg }}
+- name: Converge
+  hosts: all
+  vars:
+    __common_python: &__common_python
+      aux_pkg:
+        - uwsgi
+        - pip
+        - redis
+        - amqp
+        - psycopg2
+    __notify_config: &__notify_config
+      <<: *__common_python
+      ini_config:
+        celery:
+          broker_url: redis://127.0.0.1:6379/0
+        database:
+          peewee_url: postgres://pacifica:pacifica@127.0.0.1:5432/pacifica_notify
+    __cartd_config: &__cartd_config
+      <<: *__common_python
+      env_vars:
+        VOLUME_PATH: /srv/cartdata
+        CARTD_CONFIG: /opt/default/cartd_frontend.ini
+        CARTD_CPCONFIG: /opt/default/cartd_frontend-cp.ini
+      ini_config:
+        database:
+          peewee_url: postgres://pacifica:pacifica@127.0.0.1:5432/pacifica_cartd
+        celery:
+          broker_url: redis://127.0.0.1:6379/1
+    __ingest_config: &__ingest_config
+      <<: *__common_python
+      env_vars:
+        VOLUME_PATH: /srv/ingestdata
+        INGEST_CONFIG: /opt/default/ingest_frontend.ini
+        INGEST_CPCONFIG: /opt/default/ingest_frontend-cp.ini
+      ini_config:
+        database:
+          peewee_url: postgres://pacifica:pacifica@127.0.0.1:5432/pacifica_ingest
+        celery:
+          broker_url: redis://127.0.0.1:6379/2
+    pacifica_available_services:
+      archiveinterface:
+        <<: *__common_python
+        processes: 4
+        env_vars:
+          PAI_PREFIX: /srv/archivedata
+          ARCHIVEINTERFACE_CONFIG: "/opt/default/archiveinterface.ini"
+          ARCHIVEINTERFACE_CPCONFIG: "/opt/default/archiveinterface-cp.ini"
+      metadata:
+        <<: *__common_python
+        ini_config:
+          database:
+            peewee_url: postgres://pacifica:pacifica@127.0.0.1:5432/pacifica_metadata
+      proxy:
+        <<: *__common_python
+      policy:
+        <<: *__common_python
+      uniqueid:
+        <<: *__common_python
+        ini_config:
+          database:
+            peewee_url: postgres://pacifica:pacifica@127.0.0.1:5432/pacifica_uniqueid
+      notify_backend: *__notify_config
+      notify_frontend: *__notify_config
+      ingest_backend: *__ingest_config
+      ingest_frontend: *__ingest_config
+      cartd_backend: *__cartd_config
+      cartd_frontend: *__cartd_config
+    postgresql_ext_install_dev_headers: true
+    postgresql_apt_dependencies: ["python3-psycopg2", "locales"]
+    postgresql_version: 10
+    postgresql_databases:
+      - name: pacifica_metadata
+        owner: pacifica
+      - name: pacifica_uniqueid
+        owner: pacifica
+      - name: pacifica_ingest
+        owner: pacifica
+      - name: pacifica_cartd
+        owner: pacifica
+      - name: pacifica_notify
+        owner: pacifica
+    postgresql_users:
+      - name: pacifica
+        pass: pacifica
+        password: pacifica
+  pre_tasks:
+    - include_tasks: ../common/pre-tasks.yml
+  roles:
+    - role: rh7.postgresql
+      when: |
+        (
+          ansible_os_family == 'RedHat' and
+          ansible_distribution_major_version | int < 8
+        ) or
+        ansible_os_family == 'Debian'
+    - role: rh8.postgresql
+      when:
+        - ansible_os_family == 'RedHat'
+        - ansible_distribution_major_version | int >= 8
+    - role: pacifica.ansible_pacifica
+      environment:
+        PATH: /usr/pgsql-10/bin:{% raw %}{{ ansible_env.PATH }}{% endraw %}
+      pacifica_enabled_services:
+        - metadata
+        - policy
+        - proxy
+        - uniqueid
+        - archiveinterface
+        - cartd_frontend
+        - cartd_backend
+        - ingest_frontend
+        - ingest_backend
+        - notify_frontend
+        - notify_backend

--- a/molecule/common/allinone_tests/test_archiveinterface.py
+++ b/molecule/common/allinone_tests/test_archiveinterface.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Testing module for archiveinterface to verify working."""
+
+
+def test_archiveinterface_socket(host):
+    """Test the archiveinterface default socket."""
+    sock = host.socket('tcp://0.0.0.0:8080')
+    assert sock
+
+
+def test_archiveinterface_configs(host):
+    """Test archiveinterface configs are present."""
+    test_files = [
+        '/opt/default/archiveinterface.ini',
+        '/opt/default/archiveinterface-cp.ini',
+        '/opt/default/archiveinterface',
+        '/etc/systemd/system/archiveinterface.service'
+    ]
+    for test_file in test_files:
+        run_file = host.file(test_file)
+        assert run_file.exists
+
+
+def check_archiveinterface_service(host):
+    """Check that the archiveinterface service is running on the host."""
+    assert host.service('archiveinterface').is_running
+
+
+def test_archiveinterface_return(host):
+    """Check that the archiveinterface returns properly."""
+    command = """curl --digest -L -D - http://localhost:8080/"""
+    cmd = host.run(command)
+    assert 'HTTP/1.1 200 OK' in cmd.stdout

--- a/molecule/common/allinone_tests/test_cartd.py
+++ b/molecule/common/allinone_tests/test_cartd.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Testing module for cartd to verify working."""
+
+
+def test_cartd_socket(host):
+    """Test the cartd default socket."""
+    sock = host.socket('tcp://0.0.0.0:8081')
+    assert sock
+
+
+def check_cartd_backend_service(host):
+    """Check that the cartd backend service is running on the host."""
+    assert host.service('cartd_backend').is_running
+
+
+def check_cartd_frontend_service(host):
+    """Check that the cartd frontend service is running on the host."""
+    assert host.service('cartd_frontend').is_running
+
+
+def test_cartd_return(host):
+    """Check that cartd returns properly."""
+    command = """curl --digest -L -D - http://localhost:8081/"""
+    cmd = host.run(command)
+    assert 'HTTP/1.1 200 OK' in cmd.stdout

--- a/molecule/common/allinone_tests/test_ingest.py
+++ b/molecule/common/allinone_tests/test_ingest.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Testing module for ingest to verify working."""
+
+
+def test_ingest_socket(host):
+    """Test the ingest default socket."""
+    sock = host.socket('tcp://0.0.0.0:8066')
+    assert sock
+
+
+def check_ingest_backend_service(host):
+    """Check that the ingest backend service is running on the host."""
+    assert host.service('ingest_backend').is_running
+
+
+def check_ingest_frontend_service(host):
+    """Check that the ingest frontend service is running on the host."""
+    assert host.service('ingest_frontend').is_running
+
+
+def test_ingest_return(host):
+    """Check that ingest returns properly."""
+    command = """curl --digest -L -D - http://localhost:8066/"""
+    cmd = host.run(command)
+    assert 'HTTP/1.1 200 OK' in cmd.stdout

--- a/molecule/common/allinone_tests/test_metadata.py
+++ b/molecule/common/allinone_tests/test_metadata.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Testing module for metadata to verify working."""
+
+
+def test_metadata_socket(host):
+    """Test the metadata default socket."""
+    sock = host.socket('tcp://0.0.0.0:8121').is_listening
+    assert sock
+
+
+def check_metadata_service(host):
+    """Check that the metadata service is running on the host."""
+    assert host.service('metadata').is_running
+
+
+def test_metadata_return(host):
+    """Check that metadata returns properly."""
+    command = """curl --digest -L -D - http://localhost:8121/"""
+    cmd = host.run(command)
+    assert 'HTTP/1.1 200 OK' in cmd.stdout

--- a/molecule/common/allinone_tests/test_notify.py
+++ b/molecule/common/allinone_tests/test_notify.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Testing module for notifictaions to verify working."""
+
+
+def test_notifications_socket(host):
+    """Test the notifications default socket."""
+    sock = host.socket('tcp://0.0.0.0:8070')
+    assert sock
+
+
+def check_notify_backend_service(host):
+    """Check that the notify backend service is running on the host."""
+    assert host.service('notify_backend').is_running
+
+
+def check_notify_frontend_service(host):
+    """Check that the notify frontend service is running on the host."""
+    assert host.service('ingest_frontend').is_running
+
+
+def test_notifications_return(host):
+    """Check that notifications returns properly."""
+    command = """curl --digest -L -D - http://localhost:8070/"""
+    cmd = host.run(command)
+    assert 'HTTP/1.1 405 Method Not Allowed' in cmd.stdout

--- a/molecule/common/allinone_tests/test_policy.py
+++ b/molecule/common/allinone_tests/test_policy.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Testing module for policy to verify working."""
+
+
+def test_policy_socket(host):
+    """Test the policy default socket."""
+    sock = host.socket('tcp://0.0.0.0:8181').is_listening
+    assert sock
+
+
+def check_policy_service(host):
+    """Check that the policy service is running on the host."""
+    assert host.service('policy').is_running
+
+
+def test_policy_return(host):
+    """Check that policy returns properly."""
+    command = """curl --digest -L -D - http://localhost:8181/"""
+    cmd = host.run(command)
+    assert 'HTTP/1.1 200 OK' in cmd.stdout

--- a/molecule/common/allinone_tests/test_postgresql.py
+++ b/molecule/common/allinone_tests/test_postgresql.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Testing module for elasticsearch to verify working."""
+
+
+def test_postgresql_socket(host):
+    """Test the postgresql default port."""
+    sock = host.socket('tcp://127.0.0.1:5432').is_listening
+    assert sock
+
+
+def check_postgresql_service(host):
+    """Check that the postgresql service is running on the host."""
+    assert host.service('postgresql').is_running

--- a/molecule/common/allinone_tests/test_uniqueid.py
+++ b/molecule/common/allinone_tests/test_uniqueid.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Testing module for unqueid to verify working."""
+
+
+def test_uniqueid_socket(host):
+    """Test the uniqueid default port."""
+    sock = host.socket('tcp://0.0.0.0:8051').is_listening
+    assert sock
+
+
+def check_uniqueid_service(host):
+    """Check that the uniqueid service is running on the host."""
+    assert host.service('uniqueid').is_running
+
+
+def test_uniqueid_return(host):
+    """Check that uniqueid returns properly."""
+    command = """curl --digest -L -D - http://localhost:8051/"""
+    cmd = host.run(command)
+    assert 'HTTP/1.1 200 OK' in cmd.stdout

--- a/molecule/common/twoinone-converge.yml.j2
+++ b/molecule/common/twoinone-converge.yml.j2
@@ -1,0 +1,91 @@
+---
+{{ warning_msg }}
+- name: Converge
+  hosts: all
+  vars:
+    __common_python: &__common_python
+      aux_pkg:
+        - uwsgi
+        - pip
+        - redis
+        - amqp
+        - psycopg2
+    __cartd_1_config: &__cartd_1_config
+      <<: *__common_python
+      pacifica_module: cartd
+      socket_port: "8081"
+      env_vars:
+        VOLUME_PATH: /srv/cartdata1
+        CARTD_CONFIG: /opt/default/cartd_1_frontend.ini
+        CARTD_CPCONFIG: /opt/default/cartd_1_frontend-cp.ini
+      ini_config:
+        database:
+          peewee_url: postgres://pacifica:pacifica@127.0.0.1:5432/pacifica_cartd1
+        celery:
+          broker_url: redis://127.0.0.1:6379/1
+    __cartd_2_config: &__cartd_2_config
+      <<: *__common_python
+      pacifica_module: cartd
+      socket_port: "8082"
+      env_vars:
+        VOLUME_PATH: /srv/cartdata2
+        CARTD_CONFIG: /opt/default/cartd_2_frontend.ini
+        CARTD_CPCONFIG: /opt/default/cartd_2_frontend-cp.ini
+      ini_config:
+        database:
+          peewee_url: postgres://pacifica:pacifica@127.0.0.1:5432/pacifica_cartd2
+        celery:
+          broker_url: redis://127.0.0.1:6379/2
+    pacifica_available_services:
+      archiveinterface:
+        <<: *__common_python
+        processes: 4
+        env_vars:
+          PAI_PREFIX: /srv/archivedata
+          ARCHIVEINTERFACE_CONFIG: "/opt/default/archiveinterface.ini"
+          ARCHIVEINTERFACE_CPCONFIG: "/opt/default/archiveinterface-cp.ini"
+      cartd_1_backend:
+        <<: *__cartd_1_config
+        celery: true
+        no_db: true
+      cartd_1_frontend: *__cartd_1_config
+      cartd_2_backend:
+        <<: *__cartd_2_config
+        celery: true
+        no_db: true
+      cartd_2_frontend: *__cartd_2_config
+    postgresql_ext_install_dev_headers: true
+    postgresql_apt_dependencies: ["python3-psycopg2", "locales"]
+    postgresql_version: 10
+    postgresql_databases:
+      - name: pacifica_cartd1
+        owner: pacifica
+      - name: pacifica_cartd2
+        owner: pacifica
+    postgresql_users:
+      - name: pacifica
+        pass: pacifica
+        password: pacifica
+  pre_tasks:
+    - include_tasks: ../common/pre-tasks.yml
+  roles:
+    - role: rh7.postgresql
+      when: |
+        (
+          ansible_os_family == 'RedHat' and
+          ansible_distribution_major_version | int < 8
+        ) or
+        ansible_os_family == 'Debian'
+    - role: rh8.postgresql
+      when:
+        - ansible_os_family == 'RedHat'
+        - ansible_distribution_major_version | int >= 8
+    - role: pacifica.ansible_pacifica
+      environment:
+        PATH: /usr/pgsql-10/bin:{% raw %}{{ ansible_env.PATH }}{% endraw %}
+      pacifica_enabled_services:
+        - archiveinterface
+        - cartd_1_frontend
+        - cartd_1_backend
+        - cartd_2_frontend
+        - cartd_2_backend

--- a/molecule/common/twoinone_tests/test_archiveinterface.py
+++ b/molecule/common/twoinone_tests/test_archiveinterface.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Testing module for archiveinterface to verify working."""
+
+
+def test_archiveinterface_socket(host):
+    """Test the archiveinterface default socket."""
+    sock = host.socket('tcp://0.0.0.0:8080')
+    assert sock
+
+
+def test_archiveinterface_configs(host):
+    """Test archiveinterface configs are present."""
+    test_files = [
+        '/opt/default/archiveinterface.ini',
+        '/opt/default/archiveinterface-cp.ini',
+        '/opt/default/archiveinterface',
+        '/etc/systemd/system/archiveinterface.service'
+    ]
+    for test_file in test_files:
+        run_file = host.file(test_file)
+        assert run_file.exists
+
+
+def check_archiveinterface_service(host):
+    """Check that the archiveinterface service is running on the host."""
+    assert host.service('archiveinterface').is_running
+
+
+def test_archiveinterface_return(host):
+    """Check that the archiveinterface returns properly."""
+    command = """curl --digest -L -D - http://localhost:8080/"""
+    cmd = host.run(command)
+    assert 'HTTP/1.1 200 OK' in cmd.stdout

--- a/molecule/common/twoinone_tests/test_cartd.py
+++ b/molecule/common/twoinone_tests/test_cartd.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Testing module for cartd to verify working."""
+
+
+def test_cartd_socket(host):
+    """Test the cartd default socket."""
+    for port in [8081, 8082]:
+        sock = host.socket('tcp://0.0.0.0:{}'.format(port))
+        assert sock
+
+
+def check_cartd_backend_service(host):
+    """Check that the cartd backend service is running on the host."""
+    for svc_id in [1, 2]:
+        assert host.service('cartd_{}_backend'.format(svc_id)).is_running
+
+
+def check_cartd_frontend_service(host):
+    """Check that the cartd frontend service is running on the host."""
+    for svc_id in [1, 2]:
+        assert host.service('cartd_{}_frontend'.format(svc_id)).is_running
+
+
+def test_cartd_return(host):
+    """Check that cartd returns properly."""
+    for port in [8081, 8082]:
+        command = """curl --digest -L -D - http://localhost:{}/""".format(port)
+        cmd = host.run(command)
+        assert 'HTTP/1.1 200 OK' in cmd.stdout

--- a/molecule/gen-scenarios.py
+++ b/molecule/gen-scenarios.py
@@ -28,7 +28,9 @@ def main():
         'default',
         'in',
         'notify',
-        'out'
+        'out',
+        'allinone',
+        'twoinone'
     ]
     for scenario in scenario_list:
         molecule_tmplt = Template(open(os.path.join(molecule_dir, 'common', 'molecule.yml.j2'.format(scenario))).read())

--- a/tasks/vars.yml
+++ b/tasks/vars.yml
@@ -19,6 +19,7 @@
   include_vars: "defaults/{{ item }}.yml"
   register: vars_result
   loop: "{{ pacifica_enabled_services }}"
+  ignore_errors: true
   tags:
     - pacifica
     - pacifica_python


### PR DESCRIPTION
### Description

This adds two test suites, all-in-one and two-in-one.

  * The all-in-one contains all the pacifica services in one big
    configuration against a PostgreSQL database.

  * The two-in-one contains two configurations for two cartd
    services on one host backed with a PostgreSQL database.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

Fix #17


### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
