### PR TITLE
Quick Fix Enable Services On Boot

### DIFF
--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -7,5 +7,6 @@
   systemd:
     name: "{{ item }}"
     state: started
+    enabled: true
   loop: "{{ pacifica_enabled_services }}"
   become: true


### PR DESCRIPTION
### Description

This is a quick fix to enable the Pacifica services on boot.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
